### PR TITLE
Arrow keys now disabled when in translation

### DIFF
--- a/web/js/app/views/fancybox/jda.view.fancybox._fancybox.js
+++ b/web/js/app/views/fancybox/jda.view.fancybox._fancybox.js
@@ -157,6 +157,7 @@
       $('.translation-wrapper').show();
       $('.show-translate').hide();
       $('.translationtext-wrapper').hide();
+      jQuery.fancybox.toggleKeys();
       e.preventDefault();
     },
 		updateTags:function(name, _this)
@@ -192,6 +193,7 @@
 			$('.show-translate').show();
  			$('.translationtext-wrapper').show();
 		 	$('.translation-wrapper').hide();
+      jQuery.fancybox.toggleKeys();
 		},
 		more : function(){
 

--- a/web/js/lib/fancybox/jquery.fancybox.js
+++ b/web/js/lib/fancybox/jquery.fancybox.js
@@ -1,8 +1,8 @@
-/*! 
+/*!
  * fancyBox 2.0
  * Copyright 2011, Janis Skarnelis (www.fancyapps.com)
  * License: www.fancyapps.com/fancybox/#license
- *	
+ *
  */
 (function (window, document, $) {
 	var W = $(window),
@@ -46,6 +46,7 @@
 
 			loop: true,
 			ajax: {},
+      keyEnabled : true,
 			keys: {
 				next: [13, 32, 34, 39, 40], // enter, space, page down, right arrow, down arrow
 				prev: [8, 33, 37, 38], // backspace, page up, left arrow, up arrow
@@ -364,7 +365,9 @@
 			D.unbind('.fb');
 			W.unbind('.fb');
 		},
-
+    toggleKeys : function() {
+      F.current.keyEnabled = !F.current.keyEnabled;
+    },
 		bindEvents: function () {
 			var current = F.current,
 				keys = current.keys;
@@ -386,11 +389,11 @@
 						F.close();
 						e.preventDefault();
 
-					} else if ($.inArray(e.keyCode, keys.next) > -1) {
+					} else if ($.inArray(e.keyCode, keys.next) > -1 && current.keyEnabled) {
 						F.next();
 						e.preventDefault();
 
-					} else if ($.inArray(e.keyCode, keys.prev) > -1) {
+					} else if ($.inArray(e.keyCode, keys.prev) > -1 && current.keyEnabled) {
 						F.prev();
 						e.preventDefault();
 					}
@@ -486,7 +489,7 @@
 					url = element;
 				}
 
-				//If we have source path we can use it to load content ... 
+				//If we have source path we can use it to load content ...
 				if (url) {
 					if (isDom) {
 						rez = $(element).data('fancybox-type');
@@ -524,7 +527,7 @@
 						type = 'inline';
 						coming.content = element;
 
-						// .. or assume that we have HTML 
+						// .. or assume that we have HTML
 					} else if (coming.content) {
 						type = 'html';
 					}
@@ -660,7 +663,7 @@
 		_setContent: function () {
 			var content, loadingBay, current = F.current,
 				type = current.type;
-			
+
 			switch (type) {
 			case 'inline':
 			case 'ajax':
@@ -1197,7 +1200,7 @@
 			//This is catherine modifying fancybox source code
 			this.rel = $(this).attr('rel');
 			//END This is catherine modifying fancybox source code
-			
+
 			if (this.rel && this.rel !== '' && this.rel !== 'nofollow') {
 				group = selector.length ? $(selector).filter('[rel="' + this.rel + '"]') : $('[rel="' + this.rel + '"]');
 			}


### PR DESCRIPTION
Can now edit translations and use the arrow keys while doing so without
moving around. fixes #689
