### PR TITLE
Changes video source link to attribution uri.

### DIFF
--- a/web/js/app/views/fancybox/jda.view.fancybox._fancybox.js
+++ b/web/js/app/views/fancybox/jda.view.fancybox._fancybox.js
@@ -253,7 +253,7 @@
 				randId: this.elemId
 			};
 			
-			if (this.model.get('user_id') == 429) {
+			if (this.model.get('user_id') == 429 || this.model.get('media_type') == 'Video') {
 				blanks.sourceLink = this.model.get('attribution_uri');
 			}
 


### PR DESCRIPTION
For video items, uses the data attribution uri rather than the data uri
for the 'View Source' link.

Fixes Issue #857.

Signed-off-by: Rebecca Chen rchen@college.harvard.edu
