### PR TITLE
Admin dashboard should work for dev servers, kind of 

### DIFF
--- a/src/Zeega/AdminBundle/AdminEntity/ItemAdmin.php
+++ b/src/Zeega/AdminBundle/AdminEntity/ItemAdmin.php
@@ -20,8 +20,11 @@ class ItemAdmin extends Admin
               'Broadcast' => 'Broadcast', 'News Headline' => 'Headline', 
               'Collection' => 'Collection');
       $fileLoc = realpath("lastExport.txt");
-	  if (isset($fileLoc)) { 
+	  if ($fileLoc != "") { 
 		$lastExport = file_get_contents($fileLoc);
+	  }
+	  else {
+		$lastExport = "";
 	  }
       $formMapper
           ->add('title')

--- a/src/Zeega/AdminBundle/AdminEntity/ItemAdmin.php
+++ b/src/Zeega/AdminBundle/AdminEntity/ItemAdmin.php
@@ -20,7 +20,9 @@ class ItemAdmin extends Admin
               'Broadcast' => 'Broadcast', 'News Headline' => 'Headline', 
               'Collection' => 'Collection');
       $fileLoc = realpath("lastExport.txt");
-      $lastExport = file_get_contents($fileLoc);
+	  if (isset($fileLoc)) { 
+		$lastExport = file_get_contents($fileLoc);
+	  }
       $formMapper
           ->add('title')
           ->add('description')


### PR DESCRIPTION
If you want your admin dashboard to work on the dev server, DO THIS:

You have to change your parameters.ini file on the DEV SERVER, not locally. Our git system doesn't track the parameters file for security reasons. So on the DEV SERVER, navigate to MY directory, /var/www/CORINNE, and type sudo vim app/config/parameters.ini - you should be looking at my parameters file. Copy the first 6 database-related lines. Then go into YOUR directory, /var/www/USERNAME, type sudo vim app/config/parameters.ini, which will then bring you to YOUR parameters file, delete the database lines and replace them with the ones I had. 

So basically, your parameters.ini file should look exactly like mine except for the "directory" line. Once you do that, you should be able to access your admin dashboard at http://dev.jdarchive.org/USERNAME/web/admin/dashboard
