### PR TITLE
Filtering out non-real tags

### DIFF
--- a/src/JDA/CoreBundle/Resources/views/Widget/widget.html.twig
+++ b/src/JDA/CoreBundle/Resources/views/Widget/widget.html.twig
@@ -254,6 +254,7 @@
           $.each(tags, function(i, tag) {
           	postObj.tags.push(tag.trim());
           });
+		  postObj.tags.filter(Boolean);
 
           postObj.media_type = $("#widget-media > option:selected").val(); 
         


### PR DESCRIPTION
Fixes #838 - NULL tags and empty tags will no longer be able to be submitted in bookmarklet I think. 
