### PR TITLE
Handle "outside-" layer type prefix in video items.

### DIFF
--- a/web/js/app/views/fancybox/jda.view.fancybox.video.js
+++ b/web/js/app/views/fancybox/jda.view.fancybox.video.js
@@ -70,7 +70,11 @@ function fixVimeoUri(uri) {
 		
 		Browser.Views._Fancybox.prototype.afterShow.call(this);
 		var source;
-		switch( this.model.get("layer_type").toLowerCase() )
+                var layer_type = this.model.get("layer_type").toLowerCase();
+                if (layer_type.lastIndexOf("outside-", 0) === 0) {
+		    layer_type = layer_type.substring(8);
+		}
+		switch( layer_type )
 			{
 				case 'youtube':
                                         var uri = this.model.get('uri');

--- a/web/js/app/views/items/jda.view.item.thumb.js
+++ b/web/js/app/views/items/jda.view.item.thumb.js
@@ -54,8 +54,8 @@ function fixYoutubeUri(uri) {
 
                         // Thumbnail for YouTube video
                         if (this.model.get("media_type") === "Video" &&
-                            this.model.get("layer_type").toLowerCase() ===
-                              "youtube" &&
+			    /youtube$/.test(
+				this.model.get("layer_type").toLowerCase()) &&
                             !this.model.get("thumbnail_url")) {
                           var uri = this.model.get("uri");
                           var yt_id = fixYoutubeUri(uri);

--- a/web/js/ux/jda.ux.item.js
+++ b/web/js/ux/jda.ux.item.js
@@ -296,7 +296,11 @@ $(document).ready(function(){
       case 'Video':
 	var source;
 	var controls;
-    	switch( $('#item').data("layer_type").toLowerCase() )
+        var layer_type = $('#item').data("layer_type").toLowerCase();
+        if (layer_type.lastIndexOf("outside-", 0) === 0) {
+	    layer_type = layer_type.substring(8);
+	}
+    	switch( layer_type )
     	{
             case 'youtube':
                 var yt_uri = $('#item').data('uri');


### PR DESCRIPTION
Not the prettiest solution, but it looks like we have to support the "outside-" prefix for now because it's the only way that the bookmarklet indicates that an item shouldn't be added to the archive.

Signed-off-by: Rebecca Chen rchen@college.harvard.edu
