### PR TITLE
Fix bookmarklet server error, update team pages.

### DIFF
--- a/src/JDA/CoreBundle/Resources/translations/messages.en.xliff
+++ b/src/JDA/CoreBundle/Resources/translations/messages.en.xliff
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
@@ -1783,7 +1783,12 @@ prompt those of us who were not affected to reflect on the way we live our lives
                 <source>jda.team.content.curation</source>
                 <target>Web Seed Curation: Momoko Howell 
 		        <![CDATA[<br />]]>
-		        Web Seed Curation: Yumiko Takeda, Showa Boston Institute for Language and Culture</target>
+		        Web Seed Curation: Yumiko Takeda, Showa Boston Institute for Language and Culture
+			<![CDATA[<br />]]>
+			Web Seed Curation: Kanami Ohno, Showa Boston Institute for Language and Culture
+			<![CDATA[<br />]]>
+			Web Seed Curation: Maho Yanagisawa, Showa Boston Institute for Language and Culture
+		</target>
             </trans-unit>
             <trans-unit id="449">
                 <source>jda.team.alumni.nick</source>

--- a/src/JDA/CoreBundle/Resources/translations/messages.ja.xliff
+++ b/src/JDA/CoreBundle/Resources/translations/messages.ja.xliff
@@ -1805,8 +1805,11 @@
                 <source>jda.team.content.curation</source>
                 <target>ウェブシード　キュレーション：Momoko Howell (ハウエル・モモコ)
                     <![CDATA[<br />]]>
-             
                     ウェブシード　キュレーション：Yumiko Takeda（昭和ボストン　竹田有美子）
+                    <![CDATA[<br />]]>
+                    ウェブシード　キュレーション：Kanami Ohno（昭和ボストン　大野奏美）
+                    <![CDATA[<br />]]>
+                    ウェブシード　キュレーション：Maho Yanagisawa（昭和ボストン　柳澤真帆）
                 </target>
             </trans-unit>
             <trans-unit id="449">

--- a/src/JDA/CoreBundle/Resources/views/Widget/widget.html.twig
+++ b/src/JDA/CoreBundle/Resources/views/Widget/widget.html.twig
@@ -1,4 +1,4 @@
-﻿
+
 
 {# src/Zeega/\CoreBundle\/Resources/views/Widget/fail.widget.html.twig #}
 


### PR DESCRIPTION
Fix for https://github.com/Japan-Digital-Archives/Japan-Digital-Archive/issues/1009, team pages update for https://github.com/Japan-Digital-Archives/Japan-Digital-Archive/issues/956.

I've removed a byte order mark (U+FEFF) that the twig parser was complaining about from the beginning of the widget file.  The character doesn't display on GitHub, which is why it looks like this pull request deletes and then adds a blank line.

Signed-off-by: Rebecca Chen rchen@college.harvard.edu
