### PR TITLE
Collections page: Save and Create-Waku buttons overlapping

### DIFF
--- a/web/css/jda.css
+++ b/web/css/jda.css
@@ -353,16 +353,11 @@ margin-left: -20px;
 	background:white;
 	*/
 }
-
-button#jda-collection-create-waku
-{
-	margin-top:3px;
-}
-
 #jda-collection-create-waku
 {
 	margin:-22px 0 5px 0;
   	border-radius:0;
+	margin-top:3px;
 	display:none;
 }
 #jda-collection-create-waku i

--- a/web/css/jda.css
+++ b/web/css/jda.css
@@ -354,6 +354,11 @@ margin-left: -20px;
 	*/
 }
 
+button#jda-collection-create-waku
+{
+	margin-top:3px;
+}
+
 #jda-collection-create-waku
 {
 	margin:-22px 0 5px 0;


### PR DESCRIPTION
When adding lines to the Collection Description field (editing), "save" and "create-Waku" buttons overlap.

Added a css top-margin property to "Create-Waku" button (#jda-collection-create-waku) in jda.css 
