### PR TITLE
Fix Issue #1021 (Cannot access bookmarklet on dev server)

### DIFF
--- a/src/JDA/CoreBundle/Resources/views/Bookmarklet/bookmarklet.html.twig
+++ b/src/JDA/CoreBundle/Resources/views/Bookmarklet/bookmarklet.html.twig
@@ -46,7 +46,12 @@
 	<div id="instructional" style="font-size: 15px; width:80%">
 		
 		{% if app.environment == 'dev' %}
-		<a type="button" class="jda-home-button" draggable="true" href="javascript:window.open('http://dev.jdarchive.org/widget?url='+window.location.href+'&title='+document.title, 'JDA Bookmarklet', 'status=no,directories=no,location=no,resizable=no,menubar=no,width=400,height='+window.innerHeight+',toolbar=no');">Add to JDA</a>
+		<a type="button" class="jda-home-button" draggable="true" href="javascript:
+var url = window.location.href;
+if (url.indexOf('dev.jdarchive.org') >= 0) {
+  window.open(url.substring(0, url.lastIndexOf('web')+3)+'/widget?url='+window.location.href+'&title='+document.title, 'JDA Bookmarklet', 'status=no,directories=no,location=no,resizable=no,menubar=no,width=400,height='+window.innerHeight+',toolbar=no');
+} else { alert('This feature is not supported in dev!'); }
+">Add to JDA</a>
 		{% else %}
 		<a type="button" class="jda-home-button" draggable="true" href="javascript:window.open('http://jdarchive.org/widget?url='+window.location.href+'&title='+document.title, 'JDA Bookmarklet', 'status=no,directories=no,location=no,resizable=no,menubar=no,width=400,height='+window.innerHeight+',toolbar=no');">Add to JDA</a>
 		{% endif %}


### PR DESCRIPTION
Make the bookmarklet work in dev when the "Add to JDA" button is
clicked or the bookmark is clicked while on the JDA dev site. A
"not supported" alert is shown if the latter is attempted from a
different site.

Signed-off-by: Rebecca Chen rchen@college.harvard.edu
